### PR TITLE
In the tutorial, do `tree mynewbook/`, not `tree mybookname/`

### DIFF
--- a/docs/start/create.md
+++ b/docs/start/create.md
@@ -24,8 +24,8 @@ There are three things that you need in order to build a Jupyter Book, each of w
 For example, take a look at the book that you just created:
 
 ```console
-$ tree mybookname
-mybookname/
+$ tree mynewbook
+mynewbook
 ├── _config.yml
 ├── _toc.yml
 ├── intro.md


### PR DESCRIPTION
Minor doc change, but I'm following the tutorial for the first time and came across this. Calling `tree` on the book i just created makes more sense to me (and maybe is the intention in the tutorial?)?